### PR TITLE
Node InSim instance as `createRoot` function parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ A [React renderer](https://legacy.reactjs.org/docs/codebase-overview.html#render
 
 ## Introduction
 
-> 🚧 This project is still under development. Any API may change as needed.
+> [!WARNING]
+> This project is still under development. Any API may change as needed.
 
 React Node InSim is a [React renderer](https://legacy.reactjs.org/docs/codebase-overview.html#renderers) for [Live for Speed](https://www.lfs.net/) [InSim](https://en.lfsmanual.net/wiki/InSim.txt) buttons. It also provides [layout components](#horizontal-stack) for easier button positioning, [hooks](#hooks) for handling incoming InSim packets and tracking server connections & players.
 
@@ -187,15 +188,21 @@ pnpm add react@18 node-insim react-node-insim
 Displaying an InSim button on a local computer
 
 ```tsx
+import { InSim } from 'node-insim';
 import { InSimFlags } from 'node-insim/packets';
-import { Button, createRoot } from 'react-node-insim';
+import { Button, CONNECT_REQUEST_ID, createRoot } from 'react-node-insim';
 
-const root = createRoot({
-  name: 'React InSim',
-  host: '127.0.0.1',
-  port: 29999,
-  flags: InSimFlags.ISF_LOCAL,
+const inSim = new InSim();
+
+inSim.connect({
+  IName: 'React InSim',
+  ReqI: CONNECT_REQUEST_ID,
+  Host: '127.0.0.1',
+  Port: 29999,
+  Flags: InSimFlags.ISF_LOCAL,
 });
+
+const root = createRoot(inSim);
 
 root.render(
   <Button top={100} left={80} width={30} height={10}>

--- a/README.md
+++ b/README.md
@@ -190,13 +190,13 @@ Displaying an InSim button on a local computer
 ```tsx
 import { InSim } from 'node-insim';
 import { InSimFlags } from 'node-insim/packets';
-import { Button, CONNECT_REQUEST_ID, createRoot } from 'react-node-insim';
+import { Button, createRoot } from 'react-node-insim';
 
 const inSim = new InSim();
 
 inSim.connect({
   IName: 'React InSim',
-  ReqI: CONNECT_REQUEST_ID,
+  ReqI: 1,
   Host: '127.0.0.1',
   Port: 29999,
   Flags: InSimFlags.ISF_LOCAL,
@@ -240,12 +240,17 @@ function App() {
   );
 }
 
-const root = createRoot({
-  name: 'React InSim',
-  host: '127.0.0.1',
-  port: 29999,
-  flags: InSimFlags.ISF_LOCAL,
+const inSim = new InSim();
+
+inSim.connect({
+  IName: 'React InSim',
+  ReqI: 1,
+  Host: '127.0.0.1',
+  Port: 29999,
+  Flags: InSimFlags.ISF_LOCAL,
 });
+
+const root = createRoot(inSim);
 
 root.render(<App />);
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ It allows you to create things like this:
   <summary>Show source code</summary>
 
 ```tsx
-import type { InSim } from 'node-insim';
+import { InSim } from 'node-insim';
 import { InSimFlags, IS_BTC, IS_MST, PacketType } from 'node-insim/packets';
 import { StrictMode } from 'react';
 import {
@@ -105,12 +105,17 @@ function App() {
   );
 }
 
-const root = createRoot({
-  name: 'React InSim',
-  host: '127.0.0.1',
-  port: 29999,
-  flags: InSimFlags.ISF_LOCAL,
+const inSim = new InSim();
+
+inSim.connect({
+  IName: 'React InSim',
+  ReqI: 1,
+  Host: '127.0.0.1',
+  Port: 29999,
+  Flags: InSimFlags.ISF_LOCAL,
 });
+
+const root = createRoot(inSim);
 
 root.render(
   <StrictMode>

--- a/examples/index.tsx
+++ b/examples/index.tsx
@@ -1,5 +1,6 @@
 import './env';
 
+import { InSim } from 'node-insim';
 import { InSimFlags } from 'node-insim/packets';
 import React, { StrictMode } from 'react';
 import { ConnectionsPlayersProvider, createRoot } from 'react-node-insim';
@@ -19,13 +20,18 @@ import {
 
 const host = process.env.HOST ?? '127.0.0.1';
 
-const root = createRoot({
-  name: 'React InSim',
-  host,
-  port: process.env.PORT ? parseInt(process.env.PORT, 10) : 29999,
-  adminPassword: process.env.ADMIN ?? '',
-  flags: host === '127.0.0.1' ? InSimFlags.ISF_LOCAL : undefined,
+const inSim = new InSim();
+
+inSim.connect({
+  IName: 'React InSim',
+  ReqI: 1,
+  Host: host,
+  Port: process.env.PORT ? parseInt(process.env.PORT, 10) : 29999,
+  Admin: process.env.ADMIN ?? '',
+  Flags: host === '127.0.0.1' ? InSimFlags.ISF_LOCAL : undefined,
 });
+
+const root = createRoot(inSim);
 
 root.render(
   <StrictMode>

--- a/src/lib/hooks/useOnConnect.ts
+++ b/src/lib/hooks/useOnConnect.ts
@@ -4,11 +4,12 @@ import { PacketType } from 'node-insim/packets';
 import { useEffect, useRef } from 'react';
 import { useInSim } from 'react-node-insim';
 
-import { CONNECT_REQUEST_ID } from '../renderer/inSim';
+import { useInSimContext } from '../internals/InSimContext';
 
 export function useOnConnect(handler: InSimEvents[PacketType.ISP_VER]) {
   const handlerRef = useRef(handler);
   const inSim = useInSim();
+  const { connectRequestId } = useInSimContext();
 
   useEffect(() => {
     handlerRef.current = handler;
@@ -16,7 +17,7 @@ export function useOnConnect(handler: InSimEvents[PacketType.ISP_VER]) {
 
   useEffect(() => {
     const listener = (packet: IS_VER, inSim: InSim) => {
-      if (packet.ReqI === CONNECT_REQUEST_ID) {
+      if (packet.ReqI === connectRequestId) {
         handlerRef.current(packet, inSim);
       }
     };

--- a/src/lib/internals/InSimContext.tsx
+++ b/src/lib/internals/InSimContext.tsx
@@ -85,7 +85,7 @@ export function InSimContextProvider({
       isConnected,
       shouldClearAllButtons,
     }),
-    [inSim, isConnected, connectRequestId],
+    [inSim, isConnected, connectRequestId, shouldClearAllButtons],
   );
 
   return (

--- a/src/lib/internals/InSimContext.tsx
+++ b/src/lib/internals/InSimContext.tsx
@@ -8,6 +8,7 @@ import { log } from './logger';
 
 type InSimContextAPI = {
   inSim: InSim;
+  connectRequestId: number;
   isConnected: boolean;
   shouldClearAllButtons: boolean;
 };
@@ -80,10 +81,11 @@ export function InSimContextProvider({
   const contextValue = useMemo(
     () => ({
       inSim,
+      connectRequestId,
       isConnected,
       shouldClearAllButtons,
     }),
-    [inSim, isConnected, shouldClearAllButtons],
+    [inSim, isConnected, connectRequestId],
   );
 
   return (

--- a/src/lib/renderer/inSim/createRoot.tsx
+++ b/src/lib/renderer/inSim/createRoot.tsx
@@ -26,7 +26,7 @@ export function createRoot(
 ) {
   if (inSim.options.ReqI === undefined || inSim.options.ReqI === 0) {
     throw new Error(
-      `Failed to create root - ReqI in InSim options must be non-zero.`,
+      `Failed to create root - 'ReqI' property in InSim options must be non-zero.`,
     );
   }
 

--- a/src/lib/renderer/inSim/createRoot.tsx
+++ b/src/lib/renderer/inSim/createRoot.tsx
@@ -93,6 +93,5 @@ export function createRoot(
         null,
       );
     },
-    inSim,
   };
 }

--- a/src/lib/renderer/inSim/index.ts
+++ b/src/lib/renderer/inSim/index.ts
@@ -1,7 +1,3 @@
-export {
-  type CreateRootOptions,
-  CONNECT_REQUEST_ID,
-  createRoot,
-} from './createRoot';
+export { type CreateRootOptions, createRoot } from './createRoot';
 export * from './elements';
 export * from './types';


### PR DESCRIPTION
This is a breaking change in the API.

To decouple node-insim's InSim instance from the react-node-insim root internals, the `InSim` is now a parameter of `createRoot`. InSim connection will be handled by node-insim itself, instead of connecting inside the `createRoot` function.

To keep the `useOnConnect` hook working, there is a requirement to set a `ReqI` to a non-zero number in the InSim connection, otherwise calling `createRoot` will throw an error.

```tsx
import { InSim } from 'node-insim';
import { InSimFlags } from 'node-insim/packets';
import { Button, createRoot } from 'react-node-insim';

const inSim = new InSim();

inSim.connect({
  IName: 'React InSim',
  ReqI: 1,
  Host: '127.0.0.1',
  Port: 29999,
  Flags: InSimFlags.ISF_LOCAL,
});

const root = createRoot(inSim);

root.render(
  <Button top={100} left={80} width={30} height={10}>
    Hello InSim!
  </Button>,
);
```

Fixes #14 